### PR TITLE
Update README badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # IndexableBitVectors
 
-[![Build Status](https://travis-ci.org/bicycle1885/IndexableBitVectors.jl.svg?branch=master)](https://travis-ci.org/bicycle1885/IndexableBitVectors.jl)
+[![Build Status](https://travis-ci.org/BioJulia/IndexableBitVectors.jl.svg?branch=master)](https://travis-ci.org/BioJulia/IndexableBitVectors.jl)
+[![IndexableBitVectors.jl](http://pkg.julialang.org/badges/IndexableBitVectors.jl_0.3.svg)](http://pkg.julialang.org/?pkg=IndexableBitVectors.jl&ver=0.3)
+[![IndexableBitVectors.jl](http://pkg.julialang.org/badges/IndexableBitVectors.jl_0.4.svg)](http://pkg.julialang.org/?pkg=IndexableBitVectors.jl&ver=0.4)
 
 This package exports following operations over bit vectors with extremely fast
 speed while keeping extra memory usage small:


### PR DESCRIPTION
Update the travis badge URL, and and add pkg.julialang.org badges (which will 404 until it's run again).

Currently the travis build is failing but only because one of the tests takes too long.
